### PR TITLE
Use boolean mask to avoid deprecated usage

### DIFF
--- a/bnaf.py
+++ b/bnaf.py
@@ -187,7 +187,7 @@ class MaskedLinear(nn.Module):
         # 3. compute output and logdet of the layer
         out = F.linear(x, w, self.bias)
         logdet = self.logg + self.weight - 0.5 * v_norm.pow(2).log()
-        logdet = logdet[self.mask_d.byte()]
+        logdet = logdet[self.mask_d.bool()]
         logdet = logdet.view(1, self.data_dim, out.shape[1]//self.data_dim, x.shape[1]//self.data_dim) \
                        .expand(x.shape[0],-1,-1,-1)  # output (B, data_dim, out_dim // data_dim, in_dim // data_dim)
 


### PR DESCRIPTION
The usage of byte tensor to index torch tensor is deprecated, and will constantly output warnings on every forward pass (e.g., see [this](https://github.com/eriklindernoren/PyTorch-YOLOv3/issues/283))

Example output from running the `bnaf.py` (the only file that had this deprecated usage):

```sh
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 Start step 0; Training for 10000 steps:   0 % | | 47 / 10000[00:00 < 03:19, 49.78 it / s
 [W IndexingUtils.h: 30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 [W IndexingUtils.h:30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 Start step 0; Training for 10000 steps:   0 % | | 48 / 10000[00:00 < 03:19, 49.78 it / s
 [W IndexingUtils.h: 30] Warning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.(function expandTensors)
 ...
```

This PR switch it to a bool tensor instead.